### PR TITLE
Rootppl support

### DIFF
--- a/coreppl/src/build.mc
+++ b/coreppl/src/build.mc
@@ -4,6 +4,12 @@ include "sys.mc"
 
 include "coreppl-to-rootppl/compile.mc"
 
+let runCommandWithError = lam cmds. lam errMsg.
+  let res = sysRunCommand cmds "" "." in
+  if eqi res.returncode 0 then ()
+  else
+    error (join [errMsg, "\nstdout:\n", res.stdout, "\nstderr:\n", res.stderr])
+
 let buildMExpr = lam options. lam ast.
   -- Output the compiled mexpr code
   let outName = "out.mc" in
@@ -12,18 +18,14 @@ let buildMExpr = lam options. lam ast.
   -- Output the compiled OCaml code (unless --skip-final is specified)
   if options.skipFinal then ()
   else
-    let res = sysRunCommand ["mi", "compile", outName] "" "." in
-    if eqi res.returncode 0 then ()
-    else
-      error (join ["Compilation of generated MExpr code failed\nstdout:\n",
-                   res.stdout, "\nstderr:\n", res.stderr])
+    let msg = "Compilation of generated MExpr code failed" in
+    runCommandWithError ["mi", "compile", outName] msg
 
 let buildRootPPL = lam options. lam ast.
   let outName = "out.cu" in
   writeFile outName (printCompiledRPProg ast);
   if options.skipFinal then ()
   else
-    sysRunCommand [
-      "rootppl", outName,
-      "--stack-size", int2string options.stackSize
-    ] "" "."; ()
+    let msg = "Compilation of generated CUDA code failed" in
+    let cmds = ["rppl", outName, "--stack-size" , int2string options.stackSize] in
+    runCommandWithError cmds msg

--- a/coreppl/src/build.mc
+++ b/coreppl/src/build.mc
@@ -2,6 +2,8 @@ include "dppl-arg.mc"
 include "mexpr/mexpr.mc"
 include "sys.mc"
 
+include "coreppl-to-rootppl/compile.mc"
+
 let buildMExpr = lam options. lam ast.
   -- Output the compiled mexpr code
   let outName = "out.mc" in
@@ -15,3 +17,13 @@ let buildMExpr = lam options. lam ast.
     else
       error (join ["Compilation of generated MExpr code failed\nstdout:\n",
                    res.stdout, "\nstderr:\n", res.stderr])
+
+let buildRootPPL = lam options. lam ast.
+  let outName = "out.cu" in
+  writeFile outName (printCompiledRPProg ast);
+  if options.skipFinal then ()
+  else
+    sysRunCommand [
+      "rootppl", outName,
+      "--stack-size", int2string options.stackSize
+    ] "" "."; ()

--- a/coreppl/src/build.mc
+++ b/coreppl/src/build.mc
@@ -26,6 +26,6 @@ let buildRootPPL = lam options. lam ast.
   writeFile outName (printCompiledRPProg ast);
   if options.skipFinal then ()
   else
-    let msg = "Compilation of generated CUDA code failed" in
+    let msg = "RootPPL compilation failed" in
     let cmds = ["rppl", outName, "--stack-size" , int2string options.stackSize] in
     runCommandWithError cmds msg

--- a/coreppl/src/cppl.mc
+++ b/coreppl/src/cppl.mc
@@ -12,6 +12,7 @@ include "build.mc"
 include "src-location.mc"
 include "coreppl-to-mexpr/backcompat.mc"
 include "coreppl-to-mexpr/compile.mc"
+include "coreppl-to-rootppl/compile.mc"
 
 include "option.mc"
 include "string.mc"
@@ -45,6 +46,18 @@ match result with ParseOK r then
     -- Load the runtimes used in the provided AST, and collect identifiers of
     -- common methods within the runtimes.
     let runtimes = loadRuntimes options ast in
+
+    -- Handle the RootPPL backend in the old way, without using infers.
+    if eqString options.method "rootppl-smc" then
+      if mapIsEmpty runtimes then
+        let ast =
+          if options.transform then transform ast
+          else ast
+        in
+        let ast = rootPPLCompile options ast in
+        buildRootPPL options ast
+      else error "Use of infer is not supported by RootPPL backend"
+    else
 
     -- If no runtimes are found, it means there are no uses of 'infer' in the
     -- program. In this case, the entire AST is the model code, so we transform

--- a/coreppl/src/infer-method.mc
+++ b/coreppl/src/infer-method.mc
@@ -86,9 +86,13 @@ lang InferMethodBase = PrettyPrint + TypeCheck + InferMethodHelper
 
   -- Constructs an inference method from the arguments of a TmConApp.
   sem inferMethodFromCon : Info -> Map SID Expr -> String -> InferMethod
+  sem inferMethodFromCon info bindings =
+  | s -> errorSingle [info] (concat "Unknown inference method: " s)
 
   -- Constructs an inference method from command-line options.
   sem inferMethodFromOptions : Options -> String -> InferMethod
+  sem inferMethodFromOptions options =
+  | s -> error (concat "Unknown inference method string: " s)
 
   -- Produces a record expression containing the configuration parameters of
   -- the inference method. This record is passed to the inference runtime


### PR DESCRIPTION
Adds support for RootPPL in `cppl` through the use of the `-m rootppl-smc` argument. Also improves the error messages when using an unknown inference method - though I think it would be preferable in the long run to also print a list of the inference methods we do support.